### PR TITLE
Add basic transpilation code

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 { 
   "esversion": 6,
   "evil": true,
+  "boss": true,
   "loopfunc": true,
   "laxbreak": true,
   "jquery": true,

--- a/index.js
+++ b/index.js
@@ -125,7 +125,6 @@ function run() {
   let args = [];
   for (let elem of $("textarea.argument")) {
     if ($(elem).attr("placeholder") === "") continue;
-    console.log(elem);
     let text = elem.value;
     try {
       text = eval(text);

--- a/src/japt.js
+++ b/src/japt.js
@@ -84,38 +84,41 @@ let Japt = {
         let char = code[0]; code = code.slice(1);
         
         if ("([".includes(char)) {
+          // Append to the level and start a new one.
           levelAppend(char);
           levelStart();
         }
         else if (Japt.methodNames.includes(char)) {
-          levelAppend("." + char);
-          useJapt("(");
+          // Turn it into a method call and start a new level.
+          levelAppend("." + char + "(");
+          levelStart();
         }
         else if (char === " ") {
+          // Append a paren, and end the level if possible, prepend another paren if not.
           levelAppend(")");
-          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(") {
+          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(")
             levelEnd();
-          }
-          else {
+          else
             levelPrepend("(");
-          }
         }
         else if (char === ")") {
+          // Pretend we ran across two spaces.
           useJapt("  ");
         }
         else if (char === "]") {
-          while (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(") {
+          // Close as many parens as possible.
+          while (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(")
             levelEnd(")");
-          }
+          
+          // Append a bracket, and end the level if possible, prepend another bracket if not.
           levelAppend("]");
-          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "[") {
+          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "[")
             levelEnd();
-          }
-          else {
+          else 
             levelPrepend("[");
-          }
         }
         else {
+          // Fallback: append directly to the level.
           levelAppend(char);
         }
       }

--- a/src/japt.js
+++ b/src/japt.js
@@ -32,7 +32,8 @@ defProps(Array.prototype, {
   },
   mapAt: function (index, f) {
     if (index < 0) index += this.length;
-    return this[index] = f(this[index]);
+    this[index] = f(this[index]);
+    return this;
   }
 });
 
@@ -42,6 +43,7 @@ let Japt = {
           + "ẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣıŀṁṅȯṗṙṡṫẇẋẏżàáâæèéêìíîòóôùúû≈≠≡≢≤≥∧∨................‹›«»“‟”„",
   
   methodNames: "abcdefghijklmnopqrstuvwxyzạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣıŀṁṅȯṗṙṡṫẇẋẏżàáâæèéêìíîòóôùúû",
+  variableNames: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   
   transpile: function(code_Japt, isBinary = false) {
     // Converts from the Japt codepage to UTF-8 for easier processing.
@@ -56,24 +58,62 @@ let Japt = {
     
     // Handles the actual transpilation of the code.
     function subtranspile(code) {
-      let outp, currLevels = [""];
+      let currLevels = [[]];
       
       // Starts a new level.
       function levelStart() {
-        currLevels.push("");
+        currLevels.push([]);
       }
-      // Appends JS code to the current level.
+      // Appends JS code to the current object.
+      function objectAppend(str) {
+        if (currLevels.length === 0)
+          currLevels.push([]);
+        if (currLevels.get(-1).length === 0) 
+          currLevels.get(-1).push("");
+        currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => obj + str));
+      }
+      // Prepends JS code to the current object.
+      function objectPrepend(str) {
+        debug("Prepending to object...");
+        if (currLevels.length === 0)
+          currLevels.push([]);
+          currLevels.get(-1).push("");
+        currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => str + obj));
+        debug("Prepended to object.");
+      }
       function levelAppend(str) {
-        currLevels.mapAt(-1, obj => obj + str);
+      // Appends an object to the current level.
+      function levelAppend(obj) {
+        debug("Appending to level...");
+        currLevels.get(-1).push(obj);
+        debug("Appended to level.");
       }
-      // Prepends JS code to the current level.
       function levelPrepend(str) {
-        currLevels.mapAt(-1, obj => str + obj);
+      // Prepends an object to the current level.
+      function levelPrepend(obj) {
+        debug("Prepending to level...");
+        currLevels.get(-1).shift(obj);
+        debug("Prepended to level.");
       }
       // Ends the current level, appending it to the previous one.
-      function levelEnd(str = "") {
         str = currLevels.pop() + str;
-        levelAppend(str);
+      // Ends the current level, appending it to the last object in the previous one.
+      function levelEnd(endchar) {
+        let obj = currLevels.pop().join(", ") + endchar;
+        if (currLevels.length === 0 || currLevels.get(-1).get(-1).slice(-1) !== mirror(endchar))
+          obj = mirror(endchar) + obj;
+        objectAppend(obj);
+      }
+      // Ends as many levels as possible with the given closing brackets.
+      function levelEndAll(endchars) {
+        while (true) {
+          if (currLevels.length < 2)
+            return;
+          let lastchar = mirror(currLevels.get(-2).get(-1).slice(-1));
+          if (!endchars.includes(lastchar))
+            return;
+          levelEnd(lastchar);
+        }
       }
       // Makes the transpiler behave as if the given code were next in the source.
       function useJapt(str) {
@@ -89,17 +129,17 @@ let Japt = {
           levelStart();
         }
         else if (Japt.methodNames.includes(char)) {
-          // Turn it into a method call and start a new level.
-          levelAppend("." + char + "(");
+          // If the last char was a digit, append a space (to avoid 5.toString() syntax errors).
+          if (/\d/.test(currLevels.get(-1).get(-1).slice(-1)))
+            objectAppend(" ");
+          
+          // Turn the letter into a method call and start a new level.
+          objectAppend("." + char + "(");
           levelStart();
         }
         else if (char === " ") {
-          // Append a paren, and end the level if possible, prepend another paren if not.
-          levelAppend(")");
-          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(")
-            levelEnd();
-          else
-            levelPrepend("(");
+          // End the level with a paren.
+          levelEnd(")");
         }
         else if (char === ")") {
           // Pretend we ran across two spaces.
@@ -107,27 +147,55 @@ let Japt = {
         }
         else if (char === "]") {
           // Close as many parens as possible.
-          while (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "(")
-            levelEnd(")");
+          levelEndAll(")");
           
-          // Append a bracket, and end the level if possible, prepend another bracket if not.
-          levelAppend("]");
-          if (currLevels.length > 1 && currLevels.get(-2).slice(-1) === "[")
-            levelEnd();
-          else 
-            levelPrepend("[");
+          // End the level with a square bracket.
+          levelEnd("]");
+        }
+        else if (Japt.variableNames.includes(char)) {
+          // Append it to the level.
+          levelAppend(char);
+        }
+        else if (/\d|\./.test(char)) {
+          let litNumber = char, isDecimal = false;
+          if (char === ".") isDecimal = true;
+          
+          // Leading zeroes become their own literals.
+          if (litNumber !== "0")
+            // While the next char is a digit, or it's "." and we're not in a decimal, add it to the literal.
+            while (/^\d/.test(code) || (code[0] === "." && !isDecimal)) {
+              char = code[0]; code = code.slice(1);
+              litNumber += char;
+              if (char === ".")
+                isDecimal = true;
+            }
+          
+          // If it's just ".", turn it into ".1".
+          if (litNumber === ".")
+            litNumber = ".1";
+          
+          // Add a leading 0 for decimals.
+          if (litNumber[0] === ".")
+            litNumber = "0" + litNumber;
+          
+          // Append to the level.
+          levelAppend(litNumber);
+        }
+        else if (char === ",") {
+          // Commas are inserted automatically; don't do anything extra.
         }
         else {
           // Fallback: append directly to the level.
-          levelAppend(char);
+          objectAppend(char);
         }
       }
       
+      // Close any levels left open.
       while (currLevels.length > 1) {
-        levelEnd(mirror(currLevels.get(-2).slice(-1)));
+        levelEnd(mirror(currLevels.get(-2).get(-1).slice(-1)));
       }
       
-      return currLevels[0];
+      return currLevels[0].join(", ");
     }
     
     let outp = subtranspile(code_Japt);

--- a/src/japt.js
+++ b/src/japt.js
@@ -4,22 +4,83 @@ function indent(text, level = 1) {
   return text.replace(/^/gm, "  ".repeat(level));
 }
 
+function mirror(text, reverse = true) {
+  let mirrorMap = "()[]{}<>\\/", output = "";
+  for (let char of text) {
+    let index = mirrorMap.indexOf(char);
+    if (index > -1)
+      char = mirrorMap[index ^ 1];
+    
+    output = reverse ? char + output : output + char;
+  }
+  return output;
+}
+
 let Japt = {
   
   codepage: "₀₁₂₃₄₅₆₇₈₉₊₋₍₎¼¾⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁽⁾½⅟ !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶"
           + "ẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣıŀṁṅȯṗṙṡṫẇẋẏżàáâæèéêìíîòóôùúû≈≠≡≢≤≥∧∨................‹›«»“‟”„",
   
   transpile: function(code_Japt, isBinary = false) {
-    let code_JS;
-    
     if (isBinary) {
       code_Japt = code_Japt.replace(/[^]/g, x => Japt.codepage[x.charCodeAt()]);
     }
     
-    // TODO: transpile code
+    code_Japt = code_Japt
+      .replace(/\n/g, '¶')
+      .replace(/\t/g, 'ṭ');
     
-    let returnIndex = code_Japt.lastIndexOf(';') + 1;
-    code_JS = code_Japt.slice(0, returnIndex) + 'return ' + code_Japt.slice(returnIndex);
+    function subtranspile(code) {
+      let outp, currObjects = [""], coIndex = 0;
+      for ( ; code.length > 0; ) {
+        let char = code[0]; code = code.slice(1);
+        
+        if ("([".includes(char)) {
+          currObjects[coIndex] += char;
+          currObjects.push("");
+          coIndex++;
+        }
+        else if (char === " ") {
+          currObjects[coIndex] += ")";
+          if (currObjects.length > 1 && currObjects[coIndex - 1].slice(-1) === "(") {
+            coIndex--;
+            currObjects[coIndex] += currObjects.pop();
+          }
+          else {
+            currObjects[coIndex] = "(" + currObjects[coIndex];
+          }
+        }
+        else if (char === "]") {
+          while (currObjects.length > 1 && currObjects[coIndex - 1].slice(-1) === "(") {
+            coIndex--;
+            currObjects[coIndex] += currObjects.pop() + ")";
+          }
+          currObjects[coIndex] += "]";
+          if (currObjects.length > 1 && currObjects[coIndex - 1].slice(-1) === "[") {
+            coIndex--;
+            currObjects[coIndex] += currObjects.pop();
+          }
+          else {
+            currObjects[coIndex] = "[" + currObjects[coIndex];
+          }
+        }
+        else {
+          currObjects[coIndex] += char;
+        }
+      }
+      
+      while (coIndex > 0) {
+        coIndex--;
+        currObjects[coIndex] += currObjects.pop() + mirror(currObjects[coIndex].slice(-1));
+      }
+      
+      return currObjects[0];
+    }
+    
+    let outp = subtranspile(code_Japt);
+    
+    let returnIndex = outp.lastIndexOf(';') + 1;
+    let code_JS = outp.slice(0, returnIndex) + 'return ' + outp.slice(returnIndex);
     
     return '(function program(input, U, V, W, X, Y, Z) {\n' + indent(code_JS) + '\n})';
   }

--- a/src/japt.js
+++ b/src/japt.js
@@ -60,52 +60,36 @@ let Japt = {
     function subtranspile(code) {
       let currLevels = [[]];
       
-      let useDebug = false;
-      function debug(message) {
-        if (useDebug)
-          console.log(message, JSON.stringify(currLevels));
-      }
-      
       // Starts a new level.
       function levelStart() {
-        debug("Starting level...");
         currLevels.push([]);
       }
       // Appends JS code to the current object.
       function objectAppend(str) {
-        debug("Appending to object...");
         if (currLevels.length === 0)
           currLevels.push([]);
         if (currLevels.get(-1).length === 0) 
           currLevels.get(-1).push("");
         currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => obj + str));
-        debug("Appended to object.");
       }
       // Prepends JS code to the current object.
       function objectPrepend(str) {
-        debug("Prepending to object...");
         if (currLevels.length === 0)
           currLevels.push([]);
         if (currLevels.get(-1).length === 0) 
           currLevels.get(-1).push("");
         currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => str + obj));
-        debug("Prepended to object.");
       }
       // Appends an object to the current level.
       function levelAppend(obj) {
-        debug("Appending to level...");
         currLevels.get(-1).push(obj);
-        debug("Appended to level.");
       }
       // Prepends an object to the current level.
       function levelPrepend(obj) {
-        debug("Prepending to level...");
         currLevels.get(-1).shift(obj);
-        debug("Prepended to level.");
       }
       // Ends the current level, appending it to the last object in the previous one.
       function levelEnd(endchar) {
-        debug("Ending level " + endchar + "...");
         let obj = currLevels.pop().join(", ") + endchar;
         if (currLevels.length === 0 || currLevels.get(-1).get(-1).slice(-1) !== mirror(endchar))
           obj = mirror(endchar) + obj;
@@ -113,7 +97,6 @@ let Japt = {
       }
       // Ends as many levels as possible with the given closing brackets.
       function levelEndAll(endchars) {
-        debug("Ending all levels " + endchars + "...");
         while (true) {
           if (currLevels.length < 2)
             return;

--- a/src/japt.js
+++ b/src/japt.js
@@ -60,45 +60,52 @@ let Japt = {
     function subtranspile(code) {
       let currLevels = [[]];
       
+      let useDebug = false;
+      function debug(message) {
+        if (useDebug)
+          console.log(message, JSON.stringify(currLevels));
+      }
+      
       // Starts a new level.
       function levelStart() {
+        debug("Starting level...");
         currLevels.push([]);
       }
       // Appends JS code to the current object.
       function objectAppend(str) {
+        debug("Appending to object...");
         if (currLevels.length === 0)
           currLevels.push([]);
         if (currLevels.get(-1).length === 0) 
           currLevels.get(-1).push("");
         currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => obj + str));
+        debug("Appended to object.");
       }
       // Prepends JS code to the current object.
       function objectPrepend(str) {
         debug("Prepending to object...");
         if (currLevels.length === 0)
           currLevels.push([]);
+        if (currLevels.get(-1).length === 0) 
           currLevels.get(-1).push("");
         currLevels.mapAt(-1, arr => arr.mapAt(-1, obj => str + obj));
         debug("Prepended to object.");
       }
-      function levelAppend(str) {
       // Appends an object to the current level.
       function levelAppend(obj) {
         debug("Appending to level...");
         currLevels.get(-1).push(obj);
         debug("Appended to level.");
       }
-      function levelPrepend(str) {
       // Prepends an object to the current level.
       function levelPrepend(obj) {
         debug("Prepending to level...");
         currLevels.get(-1).shift(obj);
         debug("Prepended to level.");
       }
-      // Ends the current level, appending it to the previous one.
-        str = currLevels.pop() + str;
       // Ends the current level, appending it to the last object in the previous one.
       function levelEnd(endchar) {
+        debug("Ending level " + endchar + "...");
         let obj = currLevels.pop().join(", ") + endchar;
         if (currLevels.length === 0 || currLevels.get(-1).get(-1).slice(-1) !== mirror(endchar))
           obj = mirror(endchar) + obj;
@@ -106,6 +113,7 @@ let Japt = {
       }
       // Ends as many levels as possible with the given closing brackets.
       function levelEndAll(endchars) {
+        debug("Ending all levels " + endchars + "...");
         while (true) {
           if (currLevels.length < 2)
             return;

--- a/src/node.js
+++ b/src/node.js
@@ -24,10 +24,13 @@ let fs = require("fs");
     return content.toString().replace(/\r\n/g, "\n");
   }
 
-  for (let item of programArgs) {
+  for (let i = 0; i < programArgs.length; i++) {
+    let item = programArgs[i];
     if (/^-\D+$/.test(item)) {
       if (/u/.test(item))
         encoding = 'utf8';
+      if (/i/.test(item))
+        inputFile = programArgs[++i];
     }
     else if (!codeFile) {
       codeFile = item;


### PR DESCRIPTION
Quite basic&mdash;the current features are:
- Bracket balancing (built into the core this time around!)
  - `]` closes all open parentheses to the next bracket
  - `]` now collects everything if there's no matching `[` (`ABC]` becomes `[A, B, C]`)
- Variables (`A`-`Z`)
- Number literals
  - leading zeroes are counted as separate (`0010` becomes `0, 0, 10`)
  - multiple `.`s are counted as separate (`5.5.5.5` becomes `5.5, 0.5, 0.5`)
  - plain `.` becomes `0.1`
- Methods (none are implemented yet)
  - number literal + method inserts a space, to avoid `5.toString()` syntax errors

Up next should probably be a permalink system, then transpiling operators, strings, regexes, and shortcuts, and implementing some methods.