### PR TITLE
Add regex classes, auto-function syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,28 @@ function setVal(element, val) {
   $(element).get()[0].adjustHeight();
 }
 
+function tryTranspile(code_Japt) {
+  if (typeof Japt !== "object") {
+    let e = new Error("Could not find Japt object.");
+    $("#status").css("color", "red");
+    $("#status").text("Compilation error: " + e.message);
+    throw e;
+  }
+  
+  let code_JS = "error";
+  try {
+    code_JS = Japt.transpile(code_Japt);
+    setVal("#js-code", code_JS);
+  }
+  catch (e) {
+    $("#status").css("color", "red");
+    $("#status").text("Compilation error: " + e.message);
+    throw e;
+  }
+  
+  return code_JS;
+}
+
 // Version of japt.js to use.
 let v = new Date().toISOString().slice(0, 16), realv;
 
@@ -86,16 +108,7 @@ function runJapt(code_Japt, args, input) {
     return;
   }
   
-  let code_JS;
-  try {
-    code_JS = Japt.transpile(code_Japt);
-    setVal("#js-code", code_JS);
-  }
-  catch (e) {
-    $("#status").css("color", "red");
-    $("#status").text("Compilation error: " + e.message);
-    throw e;
-  }
+  let code_JS = tryTranspile(code_Japt);
 
   $("#status").text("Running...");
 
@@ -227,9 +240,7 @@ $(document).delegate('#code', 'keydown', function(e) {
   
   clearTimeout(timeoutID);
   timeoutID = setTimeout(function () {
-    if (typeof Japt !== "object")
-      return console.log("Could not find Japt object.");
-    let code_JS = Japt.transpile($("#code").val());
+    let code_JS = tryTranspile($("#code").val());
     setVal("#js-code", code_JS);
   }, 1000);
 });

--- a/src/japt.js
+++ b/src/japt.js
@@ -267,7 +267,7 @@ var Japt = {
         levelAppend(litString);
       }
       else if (char === "«") {
-        let litRegex = '/';
+        let litRegex = '', inClass = false;
         while (true) {
           // Consume the next char; if it doesn't exist, pretend we hit a right arrow-quote.
           if (code.length === 0)
@@ -275,16 +275,29 @@ var Japt = {
           else
             char = code[0], code = code.slice(1);
           
-          // Right arrow-quote ends the string. More options in the near future.
+          // Right arrow-quote ends the regex.
           if (char === '»') {
-            if (litRegex === '/')
+            if (inClass) {
+              litRegex += ']';
+            }
+            if (litRegex === '')
               litRegex += '.';
-            litRegex += '/g';
+            litRegex = '/' + litRegex + '/g';
             levelAppend(litRegex);
             break;
           }
+          else if (char === '₍') {
+            inClass = true;
+            litRegex += '[';
+          }
+          else if (char === '₎') {
+            if (!inClass)
+              litRegex = '[' + litRegex;
+            litRegex += ']';
+            inClass = false;
+          }
           // Escape any special regex chars, plus newline and tab.
-          else if ('/\\()[]{}?*+|^$.'.includes(char)) {
+          else if ('/\\()[]{}?*+|-^$.'.includes(char)) {
             litRegex += '\\' + char;
           }
           else if (char === '¶') {
@@ -292,6 +305,10 @@ var Japt = {
           }
           else if (char === 'ṭ') {
             litRegex += '\\t';
+          }
+          
+          else if (char === '₋') {
+            litRegex += '-';
           }
           // More features to be added in the near future.
           // Any (remaining) printable ASCII is added directly to the string.

--- a/src/japt.js
+++ b/src/japt.js
@@ -356,8 +356,19 @@ var Japt = {
         }
       }
       else if (Japt.methodNames.includes(char)) {
+        let currLevel = currLevels.get(-1);
+        if (currLevel.length === 0) {
+          console.log(JSON.stringify(currLevels.get(-2)))
+          if (currLevels.length > 1 && currLevels.get(-2).get(-1).slice(-1) === "(") {
+            objectAppend('"' + char + '"');
+            continue;
+          }
+          else {
+            objectAppend("U");
+          }
+        }
         // If the last char was a digit, append a space (to avoid 5.toString() syntax errors).
-        if (/\d/.test(currLevels.get(-1).get(-1).slice(-1)))
+        if (currLevel.length > 0 && /\d$/.test(currLevels.get(-1).get(-1)))
           objectAppend(" ");
 
         // Turn the letter into a method call and start a new level.


### PR DESCRIPTION
Additions:
- Regex character classes
  - `₍` begins a class (`[` in transpiled regex); `₎` closes a class (`]` in transpiled)
  - Open-ended classes automatically opened/closed at ends of regex
  - `₋` represents character range (`-` in transpiled)
- Auto-function syntax
  - Lowercase letter following transpiled open-paren (e.g. method call) is converted to a string
  - Lowercase letter following transpiled open-brace or bracket has a `U` prepended

Interface changes:
- Added `tryTranspile` function
  - Takes care of finding Japt object, transpiling, and displaying transpiled JS code or error message